### PR TITLE
ci: add harden-runner to GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ jobs:
     name: lib
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
       - name: Get yarn cache directory path


### PR DESCRIPTION
## Summary

- Add step-security/harden-runner v2.16.1 as the first step in all GitHub Actions workflow jobs
- Configured with egress-policy: audit to monitor outbound traffic
- Improves supply chain security for CI/CD pipelines

## References

- [StepSecurity Harden Runner](https://github.com/step-security/harden-runner)