### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-cesium-mvt-imagery-provider
+  namespace: reearth
+  description: Render MVT data on Cesium (extended for Re:Earth core)
+  annotations:
+    github.com/project-slug: reearth/reearth-cesium-mvt-imagery-provider
+  links:
+  - url: https://github.com/reearth/reearth-cesium-mvt-imagery-provider
+    title: GitHub
+    icon: github
+  tags:
+  - typescript
+spec:
+  type: service
+  lifecycle: experimental
+  owner: reearth/lib


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-cesium-mvt-imagery-provider` (namespace `reearth`)
- **Owner:** `reearth/lib`
- **Type / lifecycle:** `service` / `experimental`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.